### PR TITLE
fix: pkg version can not be pushed when build new release

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -27,6 +27,9 @@ jobs:
           version=$(node -e "import('@gkd-kit/tools').then((m) => m.stdoutGkdVersion());")
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+      - id: update_pkg_version
+        run: node -e "import('@gkd-kit/tools').then((m) => m.updatePkgVersion());"
+
       - name: Git commit
         id: commit
         run: |
@@ -61,6 +64,5 @@ jobs:
         if: ${{ steps.commit.outcome == 'success' && env.NPM_TOKEN != '' }}
         run: |
           pnpm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
-          node -e "import('@gkd-kit/tools').then((m) => m.updatePkgVersion());"
           pnpm publish --no-git-checks
           node -e "import('@gkd-kit/tools').then((m) => m.syncNpmmirror());"


### PR DESCRIPTION
修复：build新版本时，由于更新pkg version的命令在git push step之后，所以无法修改package.json中的版本号的问题